### PR TITLE
use wx.TheClipboard for copying features between two instances

### DIFF
--- a/dnaeditor_GUI.py
+++ b/dnaeditor_GUI.py
@@ -592,7 +592,8 @@ class TextEdit(DNApyBaseClass):
 			pass
 		else: #If a selection, remove sequence
 			genbank.gb.Delete(start, finish, visible=False)
-		genbank.gb.Paste(start)
+		#genbank.gb.Paste(start)
+		genbank.gb.RichPaste(start)
 		self.update_ownUI() 
 		self.update_globalUI()
 		self.stc.SetSelection(start-1, start-1)
@@ -615,7 +616,10 @@ class TextEdit(DNApyBaseClass):
 		if finish == -1:
 			raise ValueError, 'Cannot copy an empty selection'
 		else:
-			genbank.gb.Copy(start, finish)
+			#genbank.gb.Copy(start, finish)
+		
+			# try the new copy:
+			genbank.gb.RichCopy(start, finish)
 
 	def copy_reverse_complement(self):
 		'''Copy reverse complement of DNA'''

--- a/enzyme_GUI.py
+++ b/enzyme_GUI.py
@@ -835,7 +835,7 @@ class EnzymeDigestion(DNApyBaseClass):
 		if  positions == []:
 			fragments = [[dna, 1, len(dna)+1]]
 		else:
-		# else we cuts the string:
+		# else we cut the string:
 			if topology == "circular":
 				# first fragment is las cut first cut:
 				f = []
@@ -846,8 +846,10 @@ class EnzymeDigestion(DNApyBaseClass):
 				f.append(positions[len(positions)-1])	# start
 				f.append(positions[0])			# stop
 				newFragement = dnaFragment(part,positions[len(positions)-1],positions[0], len(part)) # using the new class
-				fragments.append(f)
-				fragementList.append(newFragement)
+				
+				if len(p1) > 0:				# only fragments bigger than 0
+					fragments.append(f)		# add the dna segment
+					fragementList.append(newFragement)
 			else:
 				# add two fragemtns, the last and the first one:
 				f1 = []
@@ -855,21 +857,22 @@ class EnzymeDigestion(DNApyBaseClass):
 				f1.append(p1)
 				f1.append(0)
 				f1.append(positions[0])
-				fragments.append(f1)
-				
-				
-				newFragement = dnaFragment(p1,0,positions[0], len(p1)) # new class
-				fragementList.append(newFragement)
+
+				if len(p1) > 0:				# only fragments bigger than 0
+					fragments.append(f1)		# add the dna segment
+					newFragement = dnaFragment(p1,0,positions[0], len(p1)) # new class
+					fragementList.append(newFragement)
 				
 				f2 = []
 				p2 = dna[positions[len(positions)-1]:len(dna)]
 				f2.append(p2)
 				f2.append(positions[len(positions)-1])
 				f2.append(len(dna))
-				fragments.append(f2)
+				if len(p2) > 0:				# only fragments bigger than 0
+					fragments.append(f2)		# add the dna segment
 				
-				newFragement = dnaFragment(p2,positions[len(positions)-1],len(dna), len(p2)) # new class
-				fragementList.append(newFragement)
+					newFragement = dnaFragment(p2,positions[len(positions)-1],len(dna), len(p2)) # new class
+					fragementList.append(newFragement)
 			
 			# now we have to go from first cut to second, rom second to thirt etc.
 			# our stop is the last one
@@ -881,15 +884,14 @@ class EnzymeDigestion(DNApyBaseClass):
 				f.append(positions[i-1])		# start
 				f.append(positions[i])			# stop
 				
-				fragments.append(f)			# add the dna segment
+				if len(p) > 0:				# only fragments bigger than 0
+					fragments.append(f)		# add the dna segment
 				
-				newFragement = dnaFragment(p,positions[i-1],positions[i], len(p)) # new class
-				fragementList.append(newFragement)
+					newFragement = dnaFragment(p,positions[i-1],positions[i], len(p)) # new class
+					fragementList.append(newFragement)
 				
 				i = i + 1 				# counter + 1
-		
-		
-		
+				
 		return (fragments, fragementList)
 	
 	

--- a/main.py
+++ b/main.py
@@ -262,7 +262,7 @@ class MyFrame(wx.Frame):
 		dire=dlg.GetDirectory()
 		dlg.Destroy()
 		if(genbank.gb.fileName == None or genbank.gb.fileName == "" ):
-			return1
+			return 1
 		
 		name, extension = genbank.gb.fileName.split('.')
 		if extension.lower() == 'gb':


### PR DESCRIPTION
I just implemented the use of wx.TheClipboard. This enables to store different types of content between applications.

So I made a text copy of the dna the standart. It gets pasted whenever someone copys from DNApy to gedit or somewhere else.
If you paste from DNApy to DNApy it will instead try to use a different content I  called "application/DNApy". It is the same object as the self.clipboard instance you used before.

The functions RichCopy and RichPaste handle the operations.

Take a look at the code, I think it is a rather small change to the previous state.

I now will try to make selection more powerfull, to allow selections with start>finish in circular dna.