### PR TITLE
New plasmid view

### DIFF
--- a/main.py
+++ b/main.py
@@ -750,7 +750,7 @@ Put Table here
 		
 		# reload the enzymes maybe?
 		self.restrictionEnzymes.reloadEnzymes()
-		print "reload enzymes"
+
 
 
 ######################################

--- a/options.py
+++ b/options.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python
+
+
+#This file is part of DNApy. DNApy is a DNA editor written purely in python. 
+#The program is intended to be an intuitive, fully featured, 
+#extendable, editor for molecular and synthetic biology.  
+#Enjoy!
+#
+#Copyright (C) 2014  Martin Engqvist | 
+#
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#LICENSE:
+#This file is part of DNApy.
+#
+#DNApy is free software; you can redistribute it and/or modify
+#it under the terms of the GNU General Public License as published by
+#the Free Software Foundation; either version 3 of the License, or
+#(at your option) any later version.
+# 
+#DNApy is distributed in the hope that it will be useful,
+#but WITHOUT ANY WARRANTY; without even the implied warranty of
+#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#GNU Library General Public License for more details.
+#
+#You should have received a copy of the GNU General Public License
+#along with this program; if not, write to the Free Software Foundation,
+#Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#Get source code at: https://github.com/0b0bby0/DNApy
+#
+
+
+# file to store options!
+
+
+class options():
+		
+		# plasmid view settings
+		pRadius 			= 26					# radius of plasmid
+		pArrowThick   		= 2.4					# thickness of arrow
+		pArrowHeadLength 	= 3.2 					# length of arrow head
+		pRadChange    		= pArrowThick/2			# initial space between arrow and plasmid
+		pLevAdd             = pArrowThick + 0.8		# level distance
+		
+		labelRadius			= pRadius+pRadChange+3*pArrowThick+pLevAdd # radius for labels and stuff
+		
+		
+		pFeatureBC      	 = [0, 0, 0 ]			# bordercolor of arrow 
+		pBW      			 = 0.1					# thickness of border
+		
+		pFeatureBChigh  	 = [1,0.2, 0]			# bordercolor of arrow when highlighted
+		pBWhigh  			 = 0.35					# thickness of border when highlighted
+		
+		
+		
+		#####################
+		
+		

--- a/plasmid_GUI.py
+++ b/plasmid_GUI.py
@@ -35,7 +35,6 @@
 #add 'dna ruler'
 #add rightclick menus
 
-import random
 import wx
 
 import cairo

--- a/plasmid_GUI.py
+++ b/plasmid_GUI.py
@@ -131,7 +131,12 @@ class PlasmidView(DNApyBaseDrawingClass):
 
 		dc = wx.MemoryDC()
 		dc.SelectObject(self._Buffer)
-		self.DrawCairo(dc)
+		
+		dc.SetBackground(wx.Brush("White"))	# start the DC and clear it
+		dc.Clear() 				# make sure you clear the bitmap!
+		ctx = ContextFromDC(dc)		# load it into cairo
+		self.DrawCairo(ctx)
+		
 		dc.SelectObject(wx.NullBitmap) # need to get rid of the MemoryDC before Update() is called.
 		self.Refresh()
 		self.Update()
@@ -146,7 +151,32 @@ class PlasmidView(DNApyBaseDrawingClass):
 
 
 ############### Done setting required methods #######################
+	
+	def exportMapAs(self, filepath, fileType=".svg"):
+		'''	This method is similar to update_ownUI only that it 
+			exports a file
+			it makes a surface as svg instead of wx.dc
+		'''
+		
+		# create new surface:
+		fo = file(filepath, 'w')
+		width, height = 1000,1000
+		
+		if fileType==".svg":
+			surface = cairo.SVGSurface (fo, width, height)
+		elif fileType==".png":
+			# does not work yet!
+			surface = cairo.Surface (fo, width, height) 
+		else:
+			return False
 
+		ctx = cairo.Context (surface)
+		self.DrawCairo(ctx)
+		surface.finish()
+		
+		self.update_ownUI()
+		return True
+	
 	def find_overlap(self, drawn_locations, new_range):
 		'''
 		Takes two ranges and determines whether the new range has overlaps with the old one.
@@ -182,13 +212,11 @@ class PlasmidView(DNApyBaseDrawingClass):
 
 
 
-	def DrawCairo(self, dc):
+	def DrawCairo(self, ctx):
 		''' Function that draws the whole plasmid in every aspect'''
 
-		
-		dc.SetBackground(wx.Brush("White"))	# start the DC and clear it
-		dc.Clear() 				# make sure you clear the bitmap!
-		self.ctx = ContextFromDC(dc)		# load it into cairo
+		self.ctx = ctx
+
 		
 		
 		

--- a/plasmid_GUI.py
+++ b/plasmid_GUI.py
@@ -160,7 +160,7 @@ class PlasmidView(DNApyBaseDrawingClass):
 		
 		# create new surface:
 		fo = file(filepath, 'w')
-		width, height = 1000,1000
+		width, height = 1000,1000 # set to 1000x1000, can be anything
 		
 		if fileType==".svg":
 			surface = cairo.SVGSurface (fo, width, height)
@@ -171,7 +171,7 @@ class PlasmidView(DNApyBaseDrawingClass):
 			return False
 
 		ctx = cairo.Context (surface)
-		self.DrawCairo(ctx)
+		self.DrawCairo(ctx, (width,height) )
 		surface.finish()
 		
 		self.update_ownUI()
@@ -212,19 +212,22 @@ class PlasmidView(DNApyBaseDrawingClass):
 
 
 
-	def DrawCairo(self, ctx):
+	def DrawCairo(self, ctx, exportSize=False):
 		''' Function that draws the whole plasmid in every aspect'''
 
 		self.ctx = ctx
 
 		
-		
-		
-		width, height = self.GetVirtualSize()	# set hight and width. Its 100, 100 
-		canvasWidth  = self.size[0]
-		canvasHeight = self.size[1]
-		ratio = float(canvasHeight)/ float(canvasWidth)
-		
+		if exportSize == False:
+			width, height = self.GetVirtualSize()	# set hight and width. Its 100, 100 
+			canvasWidth  = self.size[0]
+			canvasHeight = self.size[1]
+			ratio = float(canvasHeight)/ float(canvasWidth)
+		else:
+			width, height = exportSize	# set hight and width. Its 2000, 1000 maybe 
+			canvasWidth  = width
+			canvasHeight = height
+			ratio = float(canvasHeight)/ float(canvasWidth)
 		
 		self.labelHelper		= {}	# a helper variable for labels drawn into arrows!
 		

--- a/plasmid_GUI.py
+++ b/plasmid_GUI.py
@@ -115,6 +115,7 @@ class PlasmidView(DNApyBaseDrawingClass):
 
 		This code re-draws the buffer, then calls Update, which forces a paint event.
 		"""
+
 		dc = wx.MemoryDC()
 		dc.SelectObject(self._Buffer)
 		self.DrawCairo(dc)
@@ -170,7 +171,7 @@ class PlasmidView(DNApyBaseDrawingClass):
 
 	def DrawCairo(self, dc):
 		''' Function that draws the whole plasmid in every aspect'''
-		
+
 		# start the DC and clear it
 		dc.SetBackground(wx.Brush("White"))
 		dc.Clear() # make sure you clear the bitmap!
@@ -182,6 +183,8 @@ class PlasmidView(DNApyBaseDrawingClass):
 		canvasWidth  = self.size[0]
 		canvasHeight = self.size[1]
 		ratio = float(canvasHeight)/ float(canvasWidth)
+		
+		self.labelHelper		= {}
 
 		if canvasWidth != 0 and canvasHeight != 0 and canvasWidth > 100 and canvasHeight > 100:
 			self.ctx.scale(canvasWidth*ratio, canvasHeight) # Normalizing the canvas
@@ -246,14 +249,14 @@ class PlasmidView(DNApyBaseDrawingClass):
 		drawHightlight 			= False		
 		highPath       			= False	
 		
-		self.labelHelper		= {}
+		
 		
 		
 		#####################
 		# Settings
 		arrow_thickness   = 2.4							# like everything in percent
 		radius_change     = arrow_thickness/2			# initial space between arrow and plasmid
-		lev               = arrow_thickness + 0.5		# level distance
+		lev               = arrow_thickness + 0.8		# level distance
 		arrow_head_length = 3.2 						# in degree
 		
 		length            = float(len(genbank.gb.GetDNA()))
@@ -274,7 +277,7 @@ class PlasmidView(DNApyBaseDrawingClass):
 			feature     = featurelist[i]
 			
 			# variable to save as a hittest
-			hittestName = "%s%s%s" % (name, index, start)		# random pattern
+			hittestName = "%s%s" % (name, index)				# random pattern
 			self.hittest[hittestName] = []						# initialise list to store arrow and label of a feature as paths
 			self.labelHelper[hittestName] = []					# save radius of arrow
 
@@ -290,9 +293,12 @@ class PlasmidView(DNApyBaseDrawingClass):
 			# draw the arrow:
 			arrowResult, arrowResult2 = self.drawCairoArrow(feature, hittestName,ctx, radius, radius_change, lev,arrow_head_length, length, degreeMult, borderwidth, passBC, drawHightlight )
 			
+			
+			
 			if arrowResult != False:
 				highPath  = arrowResult
 				highColor = arrowResult2
+
 		
 			
 		# now draw the highlitgh arrow, so its on top:
@@ -318,7 +324,7 @@ class PlasmidView(DNApyBaseDrawingClass):
 			feature     = featurelist[i]
 		
 			# variable to save as a hittest
-			hittestName = "%s%s%s" % (name, index, start)		# random pattern
+			hittestName = "%s%s" % (name, index)		# random pattern
 			
 			# get highest level ov labels, then calculate the radius and use that as the radius to place all labels
 			# --> might work
@@ -702,6 +708,7 @@ class PlasmidView(DNApyBaseDrawingClass):
 				# check if this path is hit
 				if inFill == True or inStroke == True:
 					hit = path
+			
 					
 				self.ctx.fill()
 		
@@ -756,10 +763,12 @@ class PlasmidView(DNApyBaseDrawingClass):
 			# only update after change
 			if oldhit != hit:
 				self.update_ownUI()
+				
 		else:
 			self.Highlight = None
 			if oldhit != hit:
 				self.update_ownUI()
+		
 
 		
 		

--- a/settings
+++ b/settings
@@ -6,13 +6,13 @@ windowsize = (670, 650)
 
 ## Available colors ##
 #rv color is same as fw, just lighter
-red = {'color':'red', 'fw':'#bb553d', 'rv':'#d28a5f'}
+red = {'color':'red', 'fw':'#B01A1A', 'rv':'#CC3B3B'}
 orange = {'color':'orange','fw':'#e29425', 'rv':'#f5c27a'}
 yellow = {'color':'yellow','fw':'#ffe349', 'rv':'#fdf388'}
-green = {'color':'green','fw':'#44a153', 'rv':'#b2d562'}
-cyan = {'color':'cyan','fw':'#4c9dab', 'rv':'#7acccb'}
-blue = {'color':'blue','fw':'#5683bf', 'rv':'#9fbfdc'}
-purple = {'color':'purple','fw':'#5f5799', 'rv':'#907bbe'}
+green = {'color':'green','fw':'#159918', 'rv':'#68A819'}
+cyan = {'color':'cyan','fw':'#0EA8C7', 'rv':'#19B5B3'}
+blue = {'color':'blue','fw':'#166AC4', 'rv':'#3886D9'}
+purple = {'color':'purple','fw':'#574E96', 'rv':'#6A62A6'}
 magenta = {'color':'magenta','fw':'#a14673', 'rv':'#c57fad'}
 burgundy = {'color':'burgundy','fw':'#955050', 'rv':'#b58d8d'}
 grey = {'color':'grey','fw':'#848484', 'rv':'#c2c2c2'}


### PR DESCRIPTION
So, this is the new plasmid GUI I've written.

It uses Pycairo (http://cairographics.org/documentation/pycairo/2/) for drawing. 

As of now it only draws two circles representing the two DNA strands. Also it draws features as arrows. Reverse features are iside, 5'-3' are outside of the plasmid.

Adding labels to the plasmid can be done in the function drawCairoLabels on line 744. For calculating label positions I prepared the function labelPositions on line 906 (Both in plasmid_GUI.py).

I suppose drawing the labels should happen before drawing the features, as only than the arrows can be on top of the lines. This would require some reordering of code.

I put dummy code into drawCairoLabels() to draw lines for features without labels:

![dummy](https://cloud.githubusercontent.com/assets/3997610/5789082/3e5d1bae-9e5c-11e4-9eb6-76d6b1e20d4a.png)

I changed some colors, as I liked them better this way. Feel free to ignore those changes.